### PR TITLE
chore(renovate): add Renovate configuration file

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,7 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>ykzts/ykzts//renovate-config/default.json5',
+    ':reviewer(ykzts)'
+  ]
+}


### PR DESCRIPTION
This pull request adds a new Renovate configuration file to the repository. The configuration extends a shared preset and specifies a default reviewer.

- Renovate configuration:
  * Added a `.github/renovate.json5` file that extends a shared Renovate config (`ykzts/ykzts//renovate-config/default.json5`) and sets `ykzts` as the reviewer for Renovate pull requests.