### PR TITLE
chore(workflow): replace job name to `copilot-setup-steps`

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -10,7 +10,7 @@ on:
       - .github/workflows/copilot-setup-steps.yml
 
 jobs:
-  setup:
+  copilot-setup-steps:
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
This pull request makes a small change to the workflow configuration by renaming the `setup` job to `copilot-setup-steps` in the `.github/workflows/copilot-setup-steps.yml` file.