### PR TITLE
chore(migrations): update supabase cli version in workflow

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@f0b2f0cf6c6280ddb614e0a97e2c56de55db5104 # v1
+        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
         with:
           version: 1.223.0
 


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow by upgrading the Supabase CLI GitHub Action to a newer version. This helps ensure compatibility and access to the latest features and fixes.

- DevOps/CI:
  * Upgraded the `supabase/setup-cli` GitHub Action in `.github/workflows/deploy-migrations.yml` from an older commit to version `v1.6.0`.