### PR TITLE
build(deps): Update Supabase CLI version in workflow

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
         with:
-          version: 2.67.1
+          version: 2.70.5
 
       - name: Verify migration files
         run: |


### PR DESCRIPTION
This pull request updates the Supabase CLI version used in the deployment workflow to ensure compatibility with the latest features and bug fixes.

Workflow dependency update:

* [`.github/workflows/deploy-migrations.yml`](diffhunk://#diff-a362297ae7d6560d30f87a86c5ded53abd239f6be696aa432cc178b2a235e751L38-R38): Updated the Supabase CLI version from `1.223.0` to `2.67.1` in the deployment workflow.