### PR TITLE
chore(ci): update CI workflow to use GitHub reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - run: pnpm install
 
-      - run: pnpm check:ci
+      - run: pnpm check:ci --reporter=github
         name: Run Biome checks
 
       - run: pnpm type-check


### PR DESCRIPTION
This pull request makes a small improvement to the CI workflow by updating the Biome check command to use the GitHub reporter, which will provide better integration with GitHub's UI for reporting issues.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25-R25): Updated the Biome check command to use the `--reporter=github` flag for improved reporting in GitHub.