### PR TITLE
feat(mcp): add initial configuration for MCP servers

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,14 @@
+{
+  "inputs": [],
+  "servers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "next-devtools": {
+      "args": ["-y", "next-devtools-mcp@latest"],
+      "command": "npx",
+      "type": "stdio"
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a new `.vscode/mcp.json` configuration file for development tooling. The file defines input parameters and sets up connections to two servers, streamlining development workflows.

Development tooling configuration:

* Added `.vscode/mcp.json` with definitions for `context7` (an HTTP server) and `next-devtools` (a local server using `npx`), improving local development setup.