### PR TITLE
build(deps): Update devcontainer CI action version

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Build and test Dev Container
-        uses: devcontainers/ci@a56d055efecd725e8cfe370543b6071b79989cc8 # v0.3.2000000349
+        uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3.1900000417
         with:
           runCmd: |
             pnpm exec supabase start


### PR DESCRIPTION
This pull request updates the version of the `devcontainers/ci` GitHub Action used in the Dev Container workflow to an earlier release. This change ensures compatibility or addresses issues with the previously used version.

* Dev Container workflow: Downgraded the `devcontainers/ci` action from version `v0.3.2000000349` to `v0.3.1900000417` in `.github/workflows/devcontainer.yml`.