### PR TITLE
fix(proxy): refactor auth checks by removing `isSpacesPath`

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -32,13 +32,6 @@ function isDashboardPath(pathname: string): boolean {
   );
 }
 
-function isSpacesPath(pathname: string): boolean {
-  const SPACES_PATTERN = new RegExp(`^/(${routing.locales.join("|")})/spaces/`);
-  return (
-    pathname.startsWith("/spaces/") || Boolean(pathname.match(SPACES_PATTERN))
-  );
-}
-
 async function handleShareKeyRoute(
   request: NextRequest,
   shareKey: string
@@ -165,8 +158,8 @@ export async function proxy(request: NextRequest) {
     return authResponse;
   }
 
-  // --- 2. Supabase Auth Check for /dashboard and /spaces routes ---
-  if (isDashboardPath(pathname) || isSpacesPath(pathname)) {
+  // --- 2. Supabase Auth Check for /dashboard routes ---
+  if (isDashboardPath(pathname)) {
     return await handleAuthenticatedRoute(request, pathname);
   }
 


### PR DESCRIPTION
Removed `isSpacesPath` function and updated auth check logic.

This pull request simplifies the authentication logic in `proxy.ts` by removing special handling for the `/spaces` route. Now, only `/dashboard` routes require Supabase authentication, streamlining the route checks and reducing unnecessary complexity.

**Authentication logic changes:**

* Removed the `isSpacesPath` function and its usage, so `/spaces` routes no longer trigger Supabase authentication checks. [[1]](diffhunk://#diff-84ebb7b78a17bdd955d464accb5232ffd9eadafd97d6ca56e90c5281b7201775L35-L41) [[2]](diffhunk://#diff-84ebb7b78a17bdd955d464accb5232ffd9eadafd97d6ca56e90c5281b7201775L168-R162)

---

Resolve #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **変更**
  * スペースルートへのアクセス制御フローを更新しました。認証処理がダッシュボード関連のルートのみに限定され、スペースルートは後続のルーティングロジックで処理されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->