### PR TITLE
fix(proxy): streamline share key route handling by removing redundant authentication checks

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -152,7 +152,7 @@ export function proxy(request: NextRequest) {
     return handleAdminAuth(request, pathname);
   }
 
-  // --- 4. Share Key Rewrite Logic with Auth Check ---
+  // --- 4. Share Key Rewrite Logic ---
   if (pathname.startsWith("/@")) {
     const shareKey = pathname.slice(2);
     return handleShareKeyRoute(request, shareKey);


### PR DESCRIPTION
This pull request makes adjustments to the authentication and routing logic in `proxy.ts`, primarily by removing the authentication check from the share key route handler and simplifying the use of `await` in the main proxy function. The changes streamline the handling of share key routes and improve the code's consistency.

**Authentication and Routing Logic:**

* Removed the authentication check from the `handleShareKeyRoute` function, so share key routes no longer require user authentication.

**Code Simplification:**

* Removed unnecessary use of `await` when calling `handleAuthenticatedRoute`, `handleAdminAuth`, and `handleShareKeyRoute` in the `proxy` function, as these functions do not return promises.

---

Resolved #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 内部の認証処理と非同期処理の扱いを整理し、早期のベーシック認証チェックを追加しました。ルーティング実装が簡潔化され、内部の応答処理が効率化されていますが、ユーザー向けの挙動や認証フローに変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->