### PR TITLE
chore(coderabbit): add 'review_requested' event to CodeRabbit trigger

### DIFF
--- a/.github/workflows/trigger-coderabbit.yml
+++ b/.github/workflows/trigger-coderabbit.yml
@@ -2,7 +2,7 @@ name: Trigger CodeRabbit for Bots
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, review_requested]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration to ensure that the workflow is also triggered when a review is requested on a pull request.

- [`.github/workflows/trigger-coderabbit.yml`](diffhunk://#diff-fd5e4c0d48ddded2450ac0762ee4b2550d222f6baf2361d67b3f2c87dca68b83L5-R5): Added the `review_requested` event to the list of pull request types that trigger the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **保守作業**
  * コードレビュー要求時にワークフローが追加でトリガーされるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->