### PR TITLE
fix(supabase): update `additional_redirect_urls` for authentication

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -147,7 +147,14 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = [
+  "https://127.0.0.1:3000/auth/callback",
+  "https://127.0.0.1:3000/auth/callback?*",
+  "http://localhost:3000/auth/callback",
+  "http://localhost:3000/auth/callback?*",
+  "https://localhost:3000/auth/callback",
+  "https://localhost:3000/auth/callback?*",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).


### PR DESCRIPTION
This pull request updates the `supabase/config.toml` file to expand the list of allowed authentication redirect URLs. This change ensures that various local and secure callback URLs are permitted during the authentication process, improving compatibility with different development environments.

**Authentication redirect URL configuration:**

* Expanded the `additional_redirect_urls` list to include multiple variants of local and secure callback URLs (both HTTP and HTTPS, with and without query parameters) to support diverse local development setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定変更**
  * ローカル開発環境での認証設定を更新しました。複数のリダイレクトURLに対応することで、HTTP/HTTPSプロトコル両対応、127.0.0.1とlocalhostホスト対応など、開発環境での認証フローがより柔軟になりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->