### PR TITLE
fix(home): prevent hydration mismatch in FloatingParticles

### DIFF
--- a/app/[locale]/_components/floating-particles.tsx
+++ b/app/[locale]/_components/floating-particles.tsx
@@ -29,9 +29,11 @@ export function FloatingParticles() {
   // Start with desktop count, will adjust on client
   const [particleCount, setParticleCount] = useState(PARTICLE_COUNT);
   const [isVisible, setIsVisible] = useState(true);
-  const [particles] = useState<Particle[]>(generateParticles);
+  const [particles, setParticles] = useState<Particle[] | null>(null);
 
   useEffect(() => {
+    // Generate particles only on client side to avoid hydration mismatch
+    setParticles(generateParticles());
     // Adjust particle count based on screen size
     const updateParticleCount = () => {
       setParticleCount(
@@ -56,8 +58,8 @@ export function FloatingParticles() {
     };
   }, []);
 
-  // Don't render particles if reduced motion is preferred
-  if (shouldReduceMotion) {
+  // Don't render if reduced motion is preferred or particles not yet generated
+  if (shouldReduceMotion || !particles) {
     return null;
   }
 


### PR DESCRIPTION
Move particle generation to client-only useEffect to avoid server/client value mismatch from Math.random().

---

This pull request improves the `FloatingParticles` component by ensuring particles are only generated on the client side, which helps avoid hydration mismatches between server and client rendering. It also prevents rendering the component until the particles have been generated, improving stability and user experience.

**Client-side rendering and stability improvements:**

* Changed the `particles` state to be initialized as `null` and updated it in a `useEffect` to generate particles only on the client side, preventing hydration mismatches. ([app/[locale]/_components/floating-particles.tsxL32-R36](diffhunk://#diff-ac7092153f36b1fb4adb8e0ee55a451ec7b11b71521d5ef22e6c91c19d254d9dL32-R36))
* Updated the rendering logic to return `null` if reduced motion is preferred or if particles have not yet been generated, ensuring the component doesn't render prematurely. ([app/[locale]/_components/floating-particles.tsxL59-R62](diffhunk://#diff-ac7092153f36b1fb4adb8e0ee55a451ec7b11b71521d5ef22e6c91c19d254d9dL59-R62))

---

Close #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
- パーティクル エフェクトのクライアント側初期化処理を改善
- ページ読み込み時のレンダリング整合性の問題を解決
- モーション削減モード使用時の表示制御を強化
- エフェクト表示の安定性を向上

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->