### PR TITLE
refactor: extract reusable form and UI components

### DIFF
--- a/app/[locale]/admin/settings/_components/system-settings-form.tsx
+++ b/app/[locale]/admin/settings/_components/system-settings-form.tsx
@@ -10,6 +10,7 @@ import {
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useActionState, useEffect } from "react";
+import { InlineFieldError } from "@/components/field-errors";
 import { FormErrors } from "@/components/form-errors";
 import { Button } from "@/components/ui/button";
 import {
@@ -127,9 +128,9 @@ export function SystemSettingsForm({ initialSettings }: Props) {
                     {t("maxParticipantsHelp")}
                   </FieldDescription>
                   {field.state.meta.errors.length > 0 && (
-                    <p className="text-red-600 text-sm">
+                    <InlineFieldError>
                       {getErrorMessage(field.state.meta.errors[0])}
-                    </p>
+                    </InlineFieldError>
                   )}
                 </FieldContent>
               </Field>
@@ -168,9 +169,9 @@ export function SystemSettingsForm({ initialSettings }: Props) {
                     {t("maxSpacesPerUserHelp")}
                   </FieldDescription>
                   {field.state.meta.errors.length > 0 && (
-                    <p className="text-red-600 text-sm">
+                    <InlineFieldError>
                       {getErrorMessage(field.state.meta.errors[0])}
-                    </p>
+                    </InlineFieldError>
                   )}
                 </FieldContent>
               </Field>
@@ -207,9 +208,9 @@ export function SystemSettingsForm({ initialSettings }: Props) {
                   />
                   <FieldDescription>{t("maxTotalSpacesHelp")}</FieldDescription>
                   {field.state.meta.errors.length > 0 && (
-                    <p className="text-red-600 text-sm">
+                    <InlineFieldError>
                       {getErrorMessage(field.state.meta.errors[0])}
-                    </p>
+                    </InlineFieldError>
                   )}
                 </FieldContent>
               </Field>
@@ -248,9 +249,9 @@ export function SystemSettingsForm({ initialSettings }: Props) {
                     {t("spaceExpirationHelp")}
                   </FieldDescription>
                   {field.state.meta.errors.length > 0 && (
-                    <p className="text-red-600 text-sm">
+                    <InlineFieldError>
                       {getErrorMessage(field.state.meta.errors[0])}
-                    </p>
+                    </InlineFieldError>
                   )}
                 </FieldContent>
               </Field>

--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { FileText, Users } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { SectionHeader } from "@/components/section-header";
 import { CreateSpaceForm } from "./_components/create-space-form";
 import { SpaceActionsDropdown } from "./_components/space-actions-dropdown";
 import { StatusBadge } from "./_components/status-badge";
@@ -113,10 +114,7 @@ export default async function DashboardPage({ params }: Props) {
 
       {/* --- SECTION 3: History --- */}
       <section>
-        <h2 className="mb-4 flex items-center gap-2 font-bold text-gray-800 text-lg">
-          <FileText className="h-5 w-5" />
-          {t("historyTitle")}
-        </h2>
+        <SectionHeader icon={FileText}>{t("historyTitle")}</SectionHeader>
         {spaces.length === 0 ? (
           <div className="overflow-hidden rounded-lg border bg-white p-8 text-center shadow-sm">
             <p className="text-gray-500 text-sm">{t("historyNoSpaces")}</p>

--- a/app/[locale]/dashboard/spaces/[id]/_components/admin-management.tsx
+++ b/app/[locale]/dashboard/spaces/[id]/_components/admin-management.tsx
@@ -11,14 +11,15 @@ import { Loader2, Trash2, UserPlus, Users } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useActionState, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { FieldErrors } from "@/components/field-errors";
 import { FormErrors } from "@/components/form-errors";
 import { useConfirm } from "@/components/providers/confirm-provider";
+import { SectionHeader } from "@/components/section-header";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import type { SpaceAdmin } from "@/lib/types/space";
-import { getErrorMessage } from "@/lib/utils";
 import {
   inviteAdminFormOpts,
   inviteAdminFormSchema,
@@ -120,15 +121,12 @@ export function AdminManagement({ spaceId }: Props) {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="mb-2 flex items-center gap-2 font-bold text-lg">
-          <Users className="h-5 w-5" />
-          管理者設定
-        </h2>
-        <p className="text-gray-600 text-sm">
-          スペースを共同で管理できるユーザーを招待します。管理者はスペースの設定を編集できますが、スペースの削除や他の管理者の追加・削除はできません。
-        </p>
-      </div>
+      <SectionHeader
+        description="スペースを共同で管理できるユーザーを招待します。管理者はスペースの設定を編集できますが、スペースの削除や他の管理者の追加・削除はできません。"
+        icon={Users}
+      >
+        管理者設定
+      </SectionHeader>
 
       {/* Invite Admin Form */}
       <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
@@ -152,21 +150,10 @@ export function AdminManagement({ spaceId }: Props) {
                   type="email"
                   value={field.state.value as string}
                 />
-                {field.state.meta.errors.length > 0 && (
-                  <div className="mt-2 rounded-lg border border-red-200 bg-red-50 p-2">
-                    {field.state.meta.errors.map((error, index) => {
-                      const message = getErrorMessage(error);
-                      return (
-                        <p
-                          className="text-red-800 text-sm"
-                          key={`${message.slice(0, 20)}-${index}`}
-                        >
-                          {message}
-                        </p>
-                      );
-                    })}
-                  </div>
-                )}
+                <FieldErrors
+                  className="mt-2"
+                  errors={field.state.meta.errors}
+                />
               </Field>
             )}
           </form.Field>
@@ -194,11 +181,7 @@ export function AdminManagement({ spaceId }: Props) {
       {/* Admin List */}
       <div>
         <h3 className="mb-3 font-semibold text-sm">現在の管理者</h3>
-        {removeError && (
-          <div className="mb-3 rounded-lg border border-red-200 bg-red-50 p-3">
-            <p className="text-red-800 text-sm">{removeError}</p>
-          </div>
-        )}
+        {removeError && <FieldErrors className="mb-3" errors={[removeError]} />}
         {loading && (
           <div className="flex items-center justify-center py-8">
             <Loader2 className="h-6 w-6 animate-spin text-gray-400" />

--- a/app/[locale]/settings/account/_components/username-form.tsx
+++ b/app/[locale]/settings/account/_components/username-form.tsx
@@ -7,11 +7,13 @@ import {
   useStore,
   useTransform,
 } from "@tanstack/react-form-nextjs";
-import { AlertCircle, CheckCircle, Loader2, User } from "lucide-react";
+import { CheckCircle, Loader2, User } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useActionState, useEffect } from "react";
+import { FieldErrors } from "@/components/field-errors";
 import { FormErrors } from "@/components/form-errors";
+import { SectionHeader } from "@/components/section-header";
 import { Button } from "@/components/ui/button";
 import {
   Field,
@@ -21,7 +23,6 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { usernameSchema } from "@/lib/schemas/user";
-import { getErrorMessage } from "@/lib/utils";
 import { updateUsernameAction } from "../_lib/actions";
 import { usernameFormOpts } from "../_lib/form-options";
 
@@ -69,12 +70,9 @@ export function UsernameForm({ currentUsername }: UsernameFormProps) {
 
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-      <div className="mb-4 flex items-center gap-2">
-        <User className="h-5 w-5 text-gray-600" />
-        <h2 className="font-semibold text-lg">{t("title")}</h2>
-      </div>
-
-      <p className="mb-6 text-gray-600 text-sm">{t("description")}</p>
+      <SectionHeader description={t("description")} icon={User}>
+        {t("title")}
+      </SectionHeader>
 
       <form action={action} className="space-y-4">
         <FormErrors errors={formErrors} variant="with-icon" />
@@ -95,25 +93,10 @@ export function UsernameForm({ currentUsername }: UsernameFormProps) {
                   value={field.state.value as string}
                 />
                 <FieldDescription>{t("usernameHelp")}</FieldDescription>
-                {field.state.meta.errors.length > 0 && (
-                  <div
-                    aria-live="polite"
-                    className="mt-2 flex items-center gap-2 rounded-md bg-red-50 p-3 text-red-800 text-sm"
-                    role="alert"
-                  >
-                    <AlertCircle className="h-4 w-4 flex-shrink-0" />
-                    <span>
-                      {field.state.meta.errors.map((error, index) => {
-                        const message = getErrorMessage(error);
-                        return (
-                          <span key={`${message.slice(0, 20)}-${index}`}>
-                            {message}
-                          </span>
-                        );
-                      })}
-                    </span>
-                  </div>
-                )}
+                <FieldErrors
+                  className="mt-2"
+                  errors={field.state.meta.errors}
+                />
               </FieldContent>
             </Field>
           )}

--- a/components/field-errors.tsx
+++ b/components/field-errors.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+import { cn, getErrorMessage } from "@/lib/utils";
+
+interface FieldErrorsProps {
+  className?: string;
+  errors: unknown[];
+}
+
+/**
+ * Reusable component for displaying field-level validation errors
+ * Used with TanStack Form's field.state.meta.errors
+ *
+ * Example usage:
+ * ```tsx
+ * <form.Field name="email">
+ *   {(field) => (
+ *     <Field>
+ *       <Input {...field} />
+ *       <FieldErrors errors={field.state.meta.errors} />
+ *     </Field>
+ *   )}
+ * </form.Field>
+ * ```
+ */
+export function FieldErrors({ className, errors }: FieldErrorsProps) {
+  if (!errors || errors.length === 0) {
+    return null;
+  }
+
+  const errorMessages = errors
+    .map((error) => getErrorMessage(error))
+    .filter(
+      (message) => message.trim() !== "" && message !== "[object Object]"
+    );
+
+  if (errorMessages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "rounded-lg border border-red-200 bg-red-50 p-2",
+        className
+      )}
+      role="alert"
+    >
+      {errorMessages.map((message, index) => (
+        <p
+          className="text-red-800 text-sm"
+          key={`${message.slice(0, 20)}-${index}`}
+        >
+          {message}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+interface InlineFieldErrorProps {
+  children: ReactNode;
+}
+
+/**
+ * Alternative variant for inline error display
+ * Use when you want a more compact error message without background
+ *
+ * Example:
+ * ```tsx
+ * {field.state.meta.errors.length > 0 && (
+ *   <InlineFieldError>
+ *     {getErrorMessage(field.state.meta.errors[0])}
+ *   </InlineFieldError>
+ * )}
+ * ```
+ */
+export function InlineFieldError({ children }: InlineFieldErrorProps) {
+  return <p className="text-red-600 text-sm">{children}</p>;
+}

--- a/components/form-errors.tsx
+++ b/components/form-errors.tsx
@@ -1,20 +1,22 @@
 import { AlertCircle } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { getErrorMessage } from "@/lib/utils";
 
 interface FormErrorsProps {
-  errors: unknown[];
   className?: string;
+  errors: unknown[];
   variant?: "default" | "with-icon";
 }
 
 /**
  * Reusable component for displaying form-level validation errors
+ * Uses shadcn/ui Alert component for consistent styling
  * Filters out empty and malformed error messages
  * Uses composite keys (message + index) to handle potential duplicates while maintaining stability
  */
 export function FormErrors({
-  errors,
   className = "",
+  errors,
   variant = "default",
 }: FormErrorsProps) {
   const errorMessages = errors
@@ -29,31 +31,26 @@ export function FormErrors({
 
   if (variant === "with-icon") {
     return (
-      <div
-        aria-live="polite"
-        className={`flex items-center gap-2 rounded-md bg-red-50 p-3 text-red-800 text-sm ${className}`}
-        role="alert"
-      >
-        <AlertCircle className="h-4 w-4 flex-shrink-0" />
-        <div className="flex flex-col gap-1">
-          {errorMessages.map((message, index) => (
-            <span key={`${message.slice(0, 20)}-${index}`}>{message}</span>
-          ))}
-        </div>
-      </div>
+      <Alert className={className} variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>
+          <div className="flex flex-col gap-1">
+            {errorMessages.map((message, index) => (
+              <span key={`${message.slice(0, 20)}-${index}`}>{message}</span>
+            ))}
+          </div>
+        </AlertDescription>
+      </Alert>
     );
   }
 
   return (
-    <div className={className}>
-      {errorMessages.map((message, index) => (
-        <p
-          className="text-red-800 text-sm"
-          key={`${message.slice(0, 20)}-${index}`}
-        >
-          {message}
-        </p>
-      ))}
-    </div>
+    <Alert className={className} variant="destructive">
+      <AlertDescription>
+        {errorMessages.map((message, index) => (
+          <p key={`${message.slice(0, 20)}-${index}`}>{message}</p>
+        ))}
+      </AlertDescription>
+    </Alert>
   );
 }

--- a/components/section-header.tsx
+++ b/components/section-header.tsx
@@ -1,0 +1,34 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface SectionHeaderProps {
+  children: ReactNode;
+  description?: ReactNode;
+  icon?: LucideIcon;
+}
+
+/**
+ * Reusable component for section headers with optional icon and description
+ *
+ * Example usage:
+ * ```tsx
+ * <SectionHeader icon={Users} description="Manage administrators">
+ *   Administrator Settings
+ * </SectionHeader>
+ * ```
+ */
+export function SectionHeader({
+  children,
+  description,
+  icon: Icon,
+}: SectionHeaderProps) {
+  return (
+    <div>
+      <h2 className="mb-2 flex items-center gap-2 font-bold text-lg">
+        {Icon && <Icon className="h-5 w-5" />}
+        {children}
+      </h2>
+      {description && <p className="text-gray-600 text-sm">{description}</p>}
+    </div>
+  );
+}

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils/index"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }


### PR DESCRIPTION
## 概要

フォームやUIで重複していたHTMLパターンを共通コンポーネントとして切り出し、コードの重複を削減しました。

## 変更内容

### 新規コンポーネント

1. **`FieldErrors`** ([components/field-errors.tsx](components/field-errors.tsx))
   - フィールドレベルのバリデーションエラー表示
   - TanStack Form の `field.state.meta.errors` と統合
   - `InlineFieldError` バリアント（コンパクト表示用）も提供

2. **`SectionHeader`** ([components/section-header.tsx](components/section-header.tsx))
   - アイコン + タイトル + 説明文のセクションヘッダー
   - オプションで Lucide アイコンと説明文を指定可能

3. **shadcn/ui Alert コンポーネント**
   - `FormErrors` で使用するために追加
   - デザインシステムの一貫性向上

### 改善されたコンポーネント

- **`FormErrors`** - shadcn/ui の `Alert` コンポーネントを使用するようリファクタリング

### 適用箇所

以下のファイルで新しいコンポーネントを適用し、重複を削減：
- [admin-management.tsx](app/[locale]/dashboard/spaces/[id]/_components/admin-management.tsx) - FieldErrors, SectionHeader
- [system-settings-form.tsx](app/[locale]/admin/settings/_components/system-settings-form.tsx) - InlineFieldError
- [username-form.tsx](app/[locale]/settings/account/_components/username-form.tsx) - FieldErrors, SectionHeader  
- [dashboard/page.tsx](app/[locale]/dashboard/page.tsx) - SectionHeader

## メリット

- ✅ コードの重複削減
- ✅ デザインの一貫性向上
- ✅ メンテナンス性の向上
- ✅ shadcn/ui との統合による標準化

## テスト

- ✅ TypeScript 型チェック: 正常
- ✅ テスト: 全288テストがパス
- ✅ Biome チェック: エラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * フィールド単位のエラーメッセージ表示コンポーネント、汎用セクションヘッダー、アクセシブルなアラートUIを追加しました。

* **Refactor**
  * 各フォームで個別のエラーレンダリングを新しいエラーボックス/インライン表示に統一しました。
  * セクションの見出し・説明を共通コンポーネントで置換し、UIの一貫性とアクセシビリティを向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->