### PR TITLE
feat: add pre-release beta banner

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -18,6 +18,9 @@ SEND_EMAIL_HOOK_SECRETS=
 # ローカル開発: http://localhost:3000
 NEXT_PUBLIC_SITE_URL="http://localhost:3000"
 
+# ベータ版バナーの表示制御（正式リリース時にfalseに設定）
+NEXT_PUBLIC_SHOW_BETA_BANNER="true"
+
 # ==========================================
 # 機能フラグとアクセス制御
 # ==========================================

--- a/app/[locale]/_components/pre-release-banner.tsx
+++ b/app/[locale]/_components/pre-release-banner.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+/**
+ * 正式リリース前であることを示すバナー
+ * リポジトリがpublicになった後、正式リリースまでの間表示される
+ * NEXT_PUBLIC_SHOW_BETA_BANNER環境変数で表示を制御可能
+ */
+export function PreReleaseBanner() {
+  const t = useTranslations("PreReleaseBanner");
+  const showBanner = process.env.NEXT_PUBLIC_SHOW_BETA_BANNER === "true";
+
+  if (!showBanner) {
+    return null;
+  }
+
+  return (
+    <Alert className="rounded-none border-x-0 border-t-0" variant="default">
+      <AlertCircle className="h-4 w-4" />
+      <AlertDescription className="flex items-center gap-2">
+        <span>{t("description")}</span>
+        <a
+          className="text-purple-600 underline hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300"
+          href="https://github.com/ykzts/bingify"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {t("learnMore")}
+        </a>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -13,6 +13,7 @@ import { routing } from "@/i18n/routing";
 import { getAbsoluteUrl } from "@/lib/utils/url";
 import { Footer } from "./_components/footer";
 import { HeaderMenuWrapper } from "./_components/header-menu-wrapper";
+import { PreReleaseBanner } from "./_components/pre-release-banner";
 
 const nunito = Nunito({
   display: "swap",
@@ -56,6 +57,7 @@ export default async function LocaleLayout({
           <NextIntlClientProvider locale={locale} messages={messages}>
             <ConfirmProvider>
               <div className="flex min-h-screen flex-col">
+                <PreReleaseBanner />
                 <header className="sticky top-0 z-50 border-gray-200 border-b bg-white/80 backdrop-blur-sm dark:border-gray-800 dark:bg-gray-950/80">
                   <div className="container mx-auto flex h-16 items-center justify-between px-4">
                     <HeaderMenuWrapper />

--- a/messages/en.json
+++ b/messages/en.json
@@ -580,6 +580,10 @@
     "errorTokenExpired": "Your OAuth token has expired or been revoked. Please reconnect your account.",
     "errorUnknown": "An unexpected error occurred during OAuth verification. Please try again."
   },
+  "PreReleaseBanner": {
+    "description": "Bingify is currently in beta. Unexpected behavior or data loss may occur.",
+    "learnMore": "Learn more"
+  },
   "Privacy": {
     "metaDescription": "Read Bingify's Privacy Policy to understand how we collect, use, and protect your personal information.",
     "metaTitle": "Privacy Policy"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -580,6 +580,10 @@
     "errorTokenExpired": "OAuthトークンの有効期限が切れているか、取り消されています。アカウントを再接続してください。",
     "errorUnknown": "OAuth確認中に予期しないエラーが発生しました。もう一度お試しください。"
   },
+  "PreReleaseBanner": {
+    "description": "Bingifyは現在ベータ版です。予期しない動作やデータの損失が発生する可能性があります。",
+    "learnMore": "詳細"
+  },
   "Privacy": {
     "metaDescription": "Bingifyのプライバシーポリシーをご覧ください。個人情報の収集、利用、保護の方法について説明しています。",
     "metaTitle": "プライバシーポリシー"


### PR DESCRIPTION
## 概要

リポジトリをpublic化した後、ユーザーに対してベータ版であることを明示するためのバナーを実装しました。

## 変更内容

### 1. バナーコンポーネント

- `app/[locale]/_components/pre-release-banner.tsx` を作成
- shadcn/ui の `Alert` コンポーネントを使用
- `AlertCircle` アイコンで視覚的に注意を促す
- GitHub リポジトリへのリンクを含む
- `NEXT_PUBLIC_SHOW_BETA_BANNER` 環境変数で表示を制御

### 2. i18n メッセージ

`messages/ja.json` と `messages/en.json` に `PreReleaseBanner` 名前空間を追加：

**日本語:**
- description: "Bingifyは現在ベータ版です。予期しない動作やデータの損失が発生する可能性があります。"
- learnMore: "詳細"

**英語:**
- description: "Bingify is currently in beta. Unexpected behavior or data loss may occur."
- learnMore: "Learn more"

### 3. レイアウト統合

`app/[locale]/layout.tsx` にバナーを追加：

- ヘッダーの上に配置
- すべてのページで表示

### 4. 環境変数

`.env.local.example` に設定を追加：

- `NEXT_PUBLIC_SHOW_BETA_BANNER="true"`: バナーを表示（デフォルト）
- `NEXT_PUBLIC_SHOW_BETA_BANNER="false"`: バナーを非表示（正式リリース時）

## スクリーンショット

バナーはヘッダーの上部に表示されます：

```
┌─────────────────────────────────────────────┐
│ ⚠️ Bingifyは現在ベータ版です。予期しない動作  │
│    やデータの損失が発生する可能性があります。   │
│    詳細 →                                    │
└─────────────────────────────────────────────┘
┌─────────────────────────────────────────────┐
│ Header (Logo, Menu, etc.)                   │
└─────────────────────────────────────────────┘
```

## 正式リリース時の対応

正式リリース時には、`.env` ファイルで `NEXT_PUBLIC_SHOW_BETA_BANNER="false"` に設定することでバナーを非表示にできます。

Closes #651


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プリリリース（ベータ）バナーを追加。ページ上部に非侵襲な通知を表示し、説明文と「詳細」リンクを含む。
  * 英語・日本語の文言を追加し、多言語対応を実現。
* **Chore**
  * バナー表示を切り替える公開設定をローカル環境サンプルに追加（有効時のみ表示）。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->