### PR TITLE
chore: disable `in_progress_fortune` in coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,6 @@ chat:
 issue_enrichment:
   labeling:
     auto_apply_labels: true
-    in_progress_fortune: false
     labeling_instructions:
       - label: "type: bug"
         instructions: |
@@ -54,6 +53,7 @@ reviews:
   auto_review:
     ignore_usernames:
       - renovate[bot]
+  in_progress_fortune: false
   labeling_instructions:
     - label: "scope: frontend"
       instructions: |


### PR DESCRIPTION
This pull request includes a small configuration change to the `.coderabbit.yaml` file. The change disables the `in_progress_fortune` feature for automatic labeling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 課題エンリッチメントの自動レビュー設定に「進行中フォーチュン」を制御する新しいオン/オフオプションを追加しました。デフォルトは無効で、既存の動作には影響ありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->