### PR TITLE
chore: add environment variable for Supabase registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Setup local environment
         run: pnpm local:setup
+        env:
+          SUPABASE_INTERNAL_IMAGE_REGISTRY: ghcr.io
 
       - name: Sync environment variables
         run: pnpm dev:env


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration. The main change is setting the `SUPABASE_INTERNAL_IMAGE_REGISTRY` environment variable to `ghcr.io` during the local environment setup step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * CI環境設定を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->