### PR TITLE
メール送信Webhookの型・ロジック整理、不要なnew_email参照の削除、i18nヘッダー修正（#704）

### DIFF
--- a/app/api/auth/hooks/send-email/_lib/email-handler.ts
+++ b/app/api/auth/hooks/send-email/_lib/email-handler.ts
@@ -12,7 +12,8 @@ import type { EmailData } from "@/lib/schemas/auth-hook";
 import { getAbsoluteUrl } from "@/lib/utils/url";
 
 // ウェブフックシークレットを分割するための正規表現（例：「v1,whsec_xxx」→ 「v1」、「whsec_xxx」）
-const SECRET_SEPARATOR_REGEX = /[,\s]+/;
+const SECRET_SEPARATOR_REGEX = /[,
+]+/;
 
 /**
  * HMAC-SHA256を使用してウェブフック署名を検証
@@ -65,21 +66,28 @@ export function buildVerifyUrl(params: {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const verificationToken = params.tokenHash || params.token || "";
   const encodedVerificationToken = encodeURIComponent(verificationToken);
-  const redirectTo = encodeURIComponent(params.redirectTo);
+  const encodedRedirectTo = encodeURIComponent(params.redirectTo);
 
   if (supabaseUrl) {
     // Supabase /auth/v1/verify は token_hash を期待します
-    return `${supabaseUrl}/auth/v1/verify?type=${params.type}&token=${encodedVerificationToken}&redirect_to=${redirectTo}`;
+    return `${supabaseUrl}/auth/v1/verify?type=${params.type}&token=${encodedVerificationToken}&redirect_to=${encodedRedirectTo}`;
   }
 
   return getAbsoluteUrl(
-    `/auth/callback?token=${encodedVerificationToken}&redirect=${redirectTo}`
+    `/auth/callback?token=${encodedVerificationToken}&redirect=${encodedRedirectTo}`
   );
 }
 
 /**
  * メールアドレス変更確認メールを送信
- * 新旧両方のメールアドレスに確認メールを送信する（double_confirm_changes 有効時）
+ * Supabase double_confirm_changes: 旧メールと新メール両方の確認が必須
+ *
+ * Flow:
+ * 1. 新メール宛：確認リンク付き確認メール (token_new + token_hash_new)
+ *    ユーザーが新メールを確認してアクティベーション
+ * 2. 旧メール宛：確認リンク付き確認メール (token + token_hash)
+ *    ユーザーが変更を許可することを確認
+ *    メッセージ: "email_change_pending" → 2つ目の確認が必要なことを通知
  */
 async function handleEmailChange(
   emailData: EmailData,
@@ -87,7 +95,8 @@ async function handleEmailChange(
   locale: string,
   redirectTo: string
 ): Promise<void> {
-  // token_new + token_hash_new → 新メールアドレス用
+  // 新メールアドレス宛：確認リンク付き確認メール (token_new)
+  // 新メール確認時は message パラメータなし (確認完了時のメッセージは別途表示)
   const newToken = emailData.token_new || "";
   const newConfirmationUrl = buildVerifyUrl({
     redirectTo,
@@ -109,9 +118,10 @@ async function handleEmailChange(
     }),
   });
 
-  // token + token_hash → 旧メールアドレス用（古いAPI互換性）
-  if (emailData.old_email && emailData.token && emailData.token_hash) {
-    const oldToken = emailData.token;
+  // 旧メールアドレス宛：確認リンク付き確認メール (token)
+  // double_confirm_changes: 旧メールでも確認が必須
+  if (emailData.old_email) {
+    const oldToken = emailData.token || "";
     const oldConfirmationUrl = buildVerifyUrl({
       redirectTo,
       token: emailData.token,

--- a/app/api/auth/hooks/send-email/route.ts
+++ b/app/api/auth/hooks/send-email/route.ts
@@ -87,6 +87,12 @@ export async function POST(request: NextRequest) {
     // redirect_to はフロント計算済みの完全パスをそのまま使い、なければローカルの /auth/callback を使う
     const redirectTo = redirect_to ?? getAbsoluteUrl("/auth/callback");
 
+    // email_change イベント時、旧メールアドレスを email_data に追加
+    // handleEmailChange で2段階確認（旧メール宛通知 + 新メール宛確認リンク）を処理する
+    if (email_action_type === "email_change" && !email_data.old_email) {
+      email_data.old_email = user.email;
+    }
+
     // メールハンドラーにルーティング
     const emailSent = await handleEmailAction(
       email_action_type || "",

--- a/emails/auth/email-changed-notification-email.tsx
+++ b/emails/auth/email-changed-notification-email.tsx
@@ -28,7 +28,7 @@ export async function EmailChangedNotificationEmail({
       <Preview>{t("subject")}</Preview>
       <Body style={bodyStyle}>
         <EmailContainer>
-          <EmailHeader title="Email Change Confirmed" />
+          <EmailHeader title={t("subject")} />
 
           <Section style={contentStyle}>
             <Text style={greetingStyle}>{t("greeting")}</Text>


### PR DESCRIPTION
# 概要
- Supabase Webhookのuser型に合わせ、不要なnew_email参照・型キャストを削除
- メール送信ロジックを型安全かつシンプルに整理
- EmailChangedNotificationのヘッダーもi18n対応に修正

# 関連Issue
Closes #704

# 詳細
- user.emailのみを利用し、冗長なキャストや分岐を排除
- メールアドレス変更フローの説明コメントも整理
- EmailHeaderのtitleをt("subject")に統一

ご確認よろしくお願いします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ウェブフック署名検証機能を追加しました。

* **バグ修正**
  * メールアドレス変更時の確認フローを改善し、古いアドレスと新しいアドレスの両方の確認に対応しました。
  * メール通知の言語設定を修正しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->